### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/cleanowners.yml
+++ b/.github/workflows/cleanowners.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Run cleanowners action
-        uses: github/cleanowners@v1
+        uses: github-community-projects/cleanowners@v1
         env:
           GH_TOKEN: ${{ secrets.STORM_BOT_GITHUB_TOKEN }}
           ORGANIZATION: storm-software

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -26,7 +26,7 @@ jobs:
           echo "END_DATE=$end_date" >> "$GITHUB_ENV"
 
       - name: Run contributor action
-        uses: github/contributors@v1
+        uses: github-community-projects/contributors@v1
         env:
           GH_TOKEN: ${{ secrets.STORM_BOT_GITHUB_TOKEN }}
           START_DATE: ${{ env.START_DATE }}


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/cleanowners` | `github-community-projects/cleanowners` |
| `github/contributors` | `github-community-projects/contributors` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
